### PR TITLE
cast bytes as 8-bit unsigned int after Tcl's binary scan

### DIFF
--- a/qspy/posix/pal.c
+++ b/qspy/posix/pal.c
@@ -212,7 +212,7 @@ static QSPYEvtType ser_getEvt(unsigned char *buf, size_t *pBytes) {
     QSPYEvtType evt;
     fd_set readSet = l_readSet;
 
-    /* block indefinitely until any input source has intput */
+    /* block indefinitely until any input source has input */
     int nrec = select(l_maxFd, &readSet, 0, 0, NULL);
 
     if (nrec == 0) {
@@ -224,7 +224,7 @@ static QSPYEvtType ser_getEvt(unsigned char *buf, size_t *pBytes) {
         return QSPY_ERROR_EVT;
     }
 
-    /* any intput available from the keyboard? */
+    /* any input available from the keyboard? */
     evt = kbd_receive(&readSet, buf, pBytes);
     if (evt != QSPY_NO_EVT) {
         return evt;
@@ -336,7 +336,7 @@ static QSPYEvtType tcp_getEvt(unsigned char *buf, size_t *pBytes) {
     QSPYEvtType evt;
     fd_set readSet = l_readSet;
 
-    /* block indefinitely until any input source has intput */
+    /* block indefinitely until any input source has input */
     int nrec = select(l_maxFd, &readSet, 0, 0, NULL);
 
     if (nrec == 0) {
@@ -348,7 +348,7 @@ static QSPYEvtType tcp_getEvt(unsigned char *buf, size_t *pBytes) {
         return QSPY_ERROR_EVT;
     }
 
-    /* any intput available from the keyboard? */
+    /* any input available from the keyboard? */
     evt = kbd_receive(&readSet, buf, pBytes);
     if (evt != QSPY_NO_EVT) {
         return evt;

--- a/qspy/source/qspy_tx.c
+++ b/qspy/source/qspy_tx.c
@@ -92,14 +92,14 @@ uint32_t QSPY_encode(uint8_t *dstBuf, uint32_t dstSize,
     uint8_t b;
 
     uint8_t *dst = &dstBuf[0];
-    uint8_t const *src = &srcBuf[1]; /* skip the sequence from the soruce */
+    uint8_t const *src = &srcBuf[1]; /* skip the sequence from the source */
 
     --srcBytes; /* account for skipping the sequence number in the source */
 
     /* supply the sequence number */
     ++l_txTargetSeq;
     b = l_txTargetSeq;
-    QS_INSERT_ESC_BYTE(b); /* insert esceped sequence into destination */
+    QS_INSERT_ESC_BYTE(b); /* insert escaped sequence into destination */
 
     for (; srcBytes > 0; ++src, --srcBytes) {
         b = *src;

--- a/qspy/tcl/qspy.tcl
+++ b/qspy/tcl/qspy.tcl
@@ -394,6 +394,12 @@ proc ::qspy::rec64 {} {
         isReset   \
         qpVersion \
         b0 b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12
+    
+    # cast bytes as unsigned 8-bit int
+    foreach byte {b0 b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12} {
+        set $byte [expr $$byte&0xFF]
+    }
+
 
     variable theFmt
     set fmt [list ? c s ? i ? ? ? w]


### PR DESCRIPTION
I was having an issue running a Target program that had 32-bit pointers. I noticed that the third byte was being sent from target as 136 but was -120 after Tcl parsed the packet with binary scan. By default, binary scan will parse it as a _signed_ int but this causes issues once we try to parse the byte.