### PR TITLE
allows for explicit listing of tcl files on command line input

### DIFF
--- a/qspy/tcl/qutest.tcl
+++ b/qspy/tcl/qutest.tcl
@@ -796,7 +796,25 @@ namespace eval ::qutest {
         global ::argc ::argv
         variable theHostExe ""
         if {$::argc > 0} {  ;# argv(0) -- test-files
-            set test_files [glob -nocomplain [lindex $::argv 0]]
+            # remove any arguments ending in tcl and add to test file list
+            set test_files { }
+            set new_argv { dummy }
+            foreach arg $argv {
+                # string compares returns 0 if argument ends in tcl
+                if { [string compare -nocase [string range $arg end-3 end] .tcl] } {
+                    lappend new_argv $arg
+                } else {
+                    # if test file input uses wildcard, find matches
+                    if { [string match * $arg] } {
+                        set test_files [glob -nocomplain $arg]
+                    } else {
+                        lappend test_files $arg
+                    }
+                }
+            }
+            # make adjustments so that the rest of the argument parsing continues properly
+            set ::argv $new_argv
+            set ::argc [llength $::argv]
         } else {
             set test_files [glob -nocomplain *.tcl] ;# default *.tcl
         }

--- a/qspy/tcl/qutest.tcl
+++ b/qspy/tcl/qutest.tcl
@@ -806,7 +806,7 @@ namespace eval ::qutest {
                 } else {
                     # if test file input uses wildcard, find matches
                     if { [string match * $arg] } {
-                        set test_files [glob -nocomplain $arg]
+                        lappend test_files [glob -nocomplain $arg]
                     } else {
                         lappend test_files $arg
                     }

--- a/qspy/tcl/qutest.tcl
+++ b/qspy/tcl/qutest.tcl
@@ -806,7 +806,10 @@ namespace eval ::qutest {
                 } else {
                     # if test file input uses wildcard, find matches
                     if { [string match * $arg] } {
-                        lappend test_files [glob -nocomplain $arg]
+			set matched_files [glob -nocomplain $arg]
+			foreach f $matched_files {
+			    lappend test_files $f
+			}
                     } else {
                         lappend test_files $arg
                     }


### PR DESCRIPTION
On POSIX system had problem with Qutest where wildcard commands being expanded before being handed to Tcl and thus shifting out the remainder of the arguments.
ie: tclsh ~/qtools/qspy/tcl/qutest.tcl *.tcl posix/test_dpp would not work unless quotations were placed around '*.tcl', allowing Tcl's glob command to find matches. 

This change allows for explicit listing at command line, meaning non-POSIX systems can list out one or more Tcl scripts without needing to use a wildcard. Or non-POSIX systems may continue using wildcards.

There is a small shortcoming in the implementation that we effectively cherry-pick all arguments ending in .tcl without regard to whether they are at the beginning. Not necessarily a bad thing... but maybe a little funky at least.