### PR TITLE
Add exceptions to QSpyRecord_getStr to handle ANSI escape codes properly

### DIFF
--- a/qspy/source/qspy.c
+++ b/qspy/source/qspy.c
@@ -584,10 +584,12 @@ char const *QSpyRecord_getStr(QSpyRecord * const me) {
             }
             return s;
         }
-        else if (*p == '[') { /* replace '[' with '<' */
+        /* replace '[' with '<' */
+        else if ((*p == '[') && ((p == me->pos) || (*(p - 1) != 27))) {
             *((uint8_t *)p) = '<'; /* cast 'const' away */
         }
-        else if (*p == ']') { /* replace ']' with '>' */
+        /* replace '[' with '<' */
+        else if ((*p == ']') && ((p == me->pos) || (*(p - 1) != 27))) {
             *((uint8_t *)p) = '>'; /* cast 'const' away */
         }
     }


### PR DESCRIPTION
This PR is related to the issue https://sourceforge.net/p/qpc/feature-requests/134/
