### PR TITLE
adds qutest.py failure line number

### DIFF
--- a/qspy/py/qutest.py
+++ b/qspy/py/qutest.py
@@ -40,6 +40,7 @@ from fnmatch import fnmatchcase
 from glob import glob
 from platform import python_version
 from subprocess import Popen
+from inspect import getframeinfo, stack
 
 import struct
 import socket
@@ -691,7 +692,7 @@ class qutest:
         raise SyntaxError(msg)
 
     def _fail(self, msg1 = '', msg2 = ''):
-        print('FAIL (%.3fs):' %(qutest._time() - self._startTime))
+        print('FAIL (%.3fs):%d' %(qutest._time() - self._startTime, getframeinfo(stack()[-4][0]).lineno))
         if msg1 != '':
             print(' ', msg1)
         if msg2 != '':


### PR DESCRIPTION
This PR adds functionality to the `qutest.py` script.

Upon failure of a QUTest, the line number of the calling DSL function from the user's test script will be printed as shown below.

Ex: The line number in `test_init.py` of the failing `expect()` call is **13**.
```
QUTest unit testing front-end 6.4.0 running on Python 3.6.7
Copyright (c) 2005-2018 Quantum Leaps, www.state-machine.com
Attaching to QSPY (localhost:7701) ... OK
--------------------------------------------------
Group: test_init.py
init: FAIL (1.443s):13
  expected: "=FAILURE=> St-Init  Obj=ExAO,State=NULL->ExAO_idle"
  received: "===RTC===> St-Init  Obj=ExAO,State=NULL->ExAO_idle"
============= Target: 190326_084346 ==============
1 Groups, 1 Tests, 1 Failures, 0 Skipped (1.456s)
FAIL!
```